### PR TITLE
config.py: Add 'Zulip' Option for ROOMS_TO_JOIN

### DIFF
--- a/config.py
+++ b/config.py
@@ -89,31 +89,49 @@ IGNORE_USERNAMES = os.environ.get("IGNORE_USERNAMES",
 
 DIVERT_TO_PRIVATE = ('help', )
 
-ROOMS_TO_JOIN = (
+ROOMS_TO_JOIN = [
     'coala',
-    'coala/offtopic',
-    'cobot-test',
-    'corobo',
-    'devops',
-    'community',
-    'coala/gsoc',
-    'coala/maintainers',
     'coala-bears',
-    'bearship',
-    'gci',
-    'cobot',
-    'performance',
-    'documentation',
-    'conferences',
-    'coala/workshops',
-    'coala/artwork-corner',
-    'freelancers',
-    'editor-plugins',
+    'corobo',
     'depman',
     'ast',
-    'aspects',
-    'community'
-)
+    'gci',
+]
+
+if BACKEND == 'Gitter':
+    ROOMS_TO_JOIN += [
+        'aspects',
+        'bearship',
+        'coala',
+        'coala/artwork-corner',
+        'coala/gsoc',
+        'coala/maintainers',
+        'coala/offtopic',
+        'coala/workshops',
+        'cobot',
+        'cobot-test',
+        'community',
+        'community',
+        'conferences',
+        'devops',
+        'documentation',
+        'editor-plugins',
+        'freelancers',
+        'performance',
+    ]
+elif BACKEND == 'Zulip':
+    ROOMS_TO_JOIN += [
+        'announce',
+        'maintainers',
+        'gci-mentors-2018'
+        'gci bahasa'
+        'gitmate',
+        'gsoc',
+        'moban',
+        'offtopic',
+        'test',
+        'zulip',
+    ]
 
 if BACKEND == 'Gitter':
     ROOMS_TO_JOIN = ['coala/' + item for item in ROOMS_TO_JOIN]


### PR DESCRIPTION
Added this code which if the `BACKEND` is run as `'Zulip'`
`ROOMS_TO_JOIN` is updated accordingly.
I noticed there's not much code for Zulip(a cursory
search shows no matches in the repo). So this
will probably make someone's life easier down
the line when they port the bot.

closes #635

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
